### PR TITLE
Fix: Gif sent via giphy isn't animated

### DIFF
--- a/Sources/Image Processing/ZMAssetMetaDataEncoder.h
+++ b/Sources/Image Processing/ZMAssetMetaDataEncoder.h
@@ -35,6 +35,7 @@
                                              format:(ZMImageFormat)format
                                       correlationID:(NSUUID * __nonnull)correlationID;
 
++ (NSString * __nullable )contentTypeForImageData:(NSData * __nonnull)imageData;
 
 @end
 


### PR DESCRIPTION
…MIME type form image data.

## What's new in this PR?

expose contentTypeForImageData method for wire-ios-data-model to get MIME type form image data.