### PR TITLE
SQPIT-583 - Fix: UTTypeCopyPreferredTagWithClass return nil on M1 simulator

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4.3"
-github "wireapp/wire-ios-system" "32.0.0"
-github "wireapp/wire-ios-testing" "23.0.0"
+github "wireapp/wire-ios-system" "32.0.7"
+github "wireapp/wire-ios-testing" "23.0.1"
 github "wireapp/wire-ios-utilities" "40.0.0"

--- a/Sources/Image Processing/ZMImageDownsampleOperation.m
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.m
@@ -27,6 +27,7 @@
 
 #import "ZMImageDownsampleOperation.h"
 #import "ZMImageLoadOperation.h"
+#import <WireImages/WireImages-Swift.h>
 
 static const NSUInteger MaximumGIFImageByteCount = 5 * 1024 * 1024;
 static const double DownsampleResizeThreshold = 1.2;
@@ -180,9 +181,8 @@ static void bitmapContextReleaseData(void *releaseInfo, void *data);
             self.downsampleImageData = [self createCompressImageDataFromImage:image format:self.loadOperation.computedImageProperties.mimeType];
         }
     }
-    self.properties = [ZMIImageProperties imagePropertiesWithSize:imageSize
-                                                           length:self.downsampleImageData.length
-                                                         mimeType:CFBridgingRelease(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)mimeType, kUTTagClassMIMEType))];
+    self.properties = [self createImagePropertiesWithMimeType:mimeType imageSize:imageSize];
+
     CGImageRelease(image);
 }
 

--- a/Sources/Image Processing/ZMImageDownsampleOperation.m
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.m
@@ -181,7 +181,8 @@ static void bitmapContextReleaseData(void *releaseInfo, void *data);
             self.downsampleImageData = [self createCompressImageDataFromImage:image format:self.loadOperation.computedImageProperties.mimeType];
         }
     }
-    self.properties = [self createImagePropertiesWithMimeType:mimeType imageSize:imageSize];
+    
+    self.properties = [self createImagePropertiesWithUti:mimeType imageSize:imageSize];
 
     CGImageRelease(image);
 }

--- a/Sources/Image Processing/ZMImageDownsampleOperation.swift
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.swift
@@ -1,28 +1,57 @@
 //
-//  ZMImageDownsampleOperation.swift
-//  WireImages-ios
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
 //
-//  Created by Bill, Yiu Por Chan on 05.07.21.
-//  Copyright © 2021 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 
 import Foundation
 import CoreServices
+import UniformTypeIdentifiers
 
 extension ZMImageDownsampleOperation {
     @objc
-    func createImageProperties(mimeType: NSString, imageSize: CGSize) -> ZMIImageProperties? {
+    func createImageProperties(uti: String, imageSize: CGSize) -> ZMIImageProperties? {
         
-        ///TODO: unmanagedFileUTI on M1 simulator
-        let unmanagedFileUTI = UTTypeCopyPreferredTagWithClass(mimeType, kUTTagClassMIMEType)
-        
-        guard let retainedValue = unmanagedFileUTI?.takeRetainedValue() else {
-            return nil
+        let mimeType: String
+        if #available(iOS 14, *) {
+            guard let utType = UTType(uti) else {
+                return nil
+            }
+            ///TODO: hard code table?
+//            let jpg = UTType.jpeg
+
+            guard let preferredMIMEType = utType.preferredMIMEType else {
+                return nil
+            }
+
+            mimeType = preferredMIMEType
+        } else {
+            let unmanagedMime = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassMIMEType)
+            
+            guard let retainedValue = unmanagedMime?.takeRetainedValue() else {
+                return nil
+            }
+
+            mimeType = retainedValue as String
         }
+        
         
         return ZMIImageProperties(
             size: imageSize,
             length: UInt(downsampleImageData.count),
-            mimeType: retainedValue as String)
+            mimeType: mimeType)
     }
 }

--- a/Sources/Image Processing/ZMImageDownsampleOperation.swift
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.swift
@@ -1,0 +1,28 @@
+//
+//  ZMImageDownsampleOperation.swift
+//  WireImages-ios
+//
+//  Created by Bill, Yiu Por Chan on 05.07.21.
+//  Copyright © 2021 Wire. All rights reserved.
+//
+
+import Foundation
+import CoreServices
+
+extension ZMImageDownsampleOperation {
+    @objc
+    func createImageProperties(mimeType: NSString, imageSize: CGSize) -> ZMIImageProperties? {
+        
+        ///TODO: unmanagedFileUTI on M1 simulator
+        let unmanagedFileUTI = UTTypeCopyPreferredTagWithClass(mimeType, kUTTagClassMIMEType)
+        
+        guard let retainedValue = unmanagedFileUTI?.takeRetainedValue() else {
+            return nil
+        }
+        
+        return ZMIImageProperties(
+            size: imageSize,
+            length: UInt(downsampleImageData.count),
+            mimeType: retainedValue as String)
+    }
+}

--- a/Sources/Image Processing/ZMImageDownsampleOperation.swift
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.swift
@@ -30,14 +30,15 @@ extension ZMImageDownsampleOperation {
             guard let utType = UTType(uti) else {
                 return nil
             }
-            ///TODO: hard code table?
-//            let jpg = UTType.jpeg
 
-            guard let preferredMIMEType = utType.preferredMIMEType else {
+            if let preferredMIMEType = utType.preferredMIMEType {
+                mimeType = preferredMIMEType
+            } else if utType == UTType.jpeg {
+                ///HACK: hard code for M1 simulator, we should file a ticket to apple for this issue
+                mimeType = "image/jpeg"
+            } else {
                 return nil
             }
-
-            mimeType = preferredMIMEType
         } else {
             let unmanagedMime = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassMIMEType)
             

--- a/Sources/Image Processing/ZMImageDownsampleOperation.swift
+++ b/Sources/Image Processing/ZMImageDownsampleOperation.swift
@@ -33,6 +33,7 @@ extension ZMImageDownsampleOperation {
             if let preferredMIMEType = utType.preferredMIMEType {
                 mimeType = preferredMIMEType
             } else {
+                #if targetEnvironment(simulator)
                 ///HACK: hard code MIME when preferredMIMEType is nil for M1 simulator, we should file a ticket to apple for this issue
                 switch utType {
                 case .jpeg:
@@ -44,6 +45,9 @@ extension ZMImageDownsampleOperation {
                 default:
                     return nil
                 }
+                #else
+                return nil
+                #endif
             }
 
         } else {

--- a/WireImages.xcodeproj/project.pbxproj
+++ b/WireImages.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		87B91C4C1E5C7E5D00A5EC11 /* unsplash_preview.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 87B91C291E5C7E5D00A5EC11 /* unsplash_preview.jpg */; };
 		87B91C4D1E5C7E5D00A5EC11 /* unsplash_preview_small_profile.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 87B91C2A1E5C7E5D00A5EC11 /* unsplash_preview_small_profile.jpg */; };
 		87B91C4E1E5C7E5D00A5EC11 /* unsplash_small_profile.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 87B91C2B1E5C7E5D00A5EC11 /* unsplash_small_profile.jpg */; };
+		A9626B4B26932BEA0043CC31 /* ZMImageDownsampleOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9626B4A26932BE90043CC31 /* ZMImageDownsampleOperation.swift */; };
 		EFF7A4722271E47500F1AC33 /* Cartfile.resolved in Resources */ = {isa = PBXBuildFile; fileRef = EFF7A46F2271E47400F1AC33 /* Cartfile.resolved */; };
 		EFF7A4732271E47500F1AC33 /* Cartfile.private in Resources */ = {isa = PBXBuildFile; fileRef = EFF7A4702271E47400F1AC33 /* Cartfile.private */; };
 		EFF7A4742271E47500F1AC33 /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = EFF7A4712271E47500F1AC33 /* Cartfile */; };
@@ -212,6 +213,7 @@
 		87B91C291E5C7E5D00A5EC11 /* unsplash_preview.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_preview.jpg; sourceTree = "<group>"; };
 		87B91C2A1E5C7E5D00A5EC11 /* unsplash_preview_small_profile.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_preview_small_profile.jpg; sourceTree = "<group>"; };
 		87B91C2B1E5C7E5D00A5EC11 /* unsplash_small_profile.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = unsplash_small_profile.jpg; sourceTree = "<group>"; };
+		A9626B4A26932BE90043CC31 /* ZMImageDownsampleOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMImageDownsampleOperation.swift; sourceTree = "<group>"; };
 		EFF7A46F2271E47400F1AC33 /* Cartfile.resolved */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
 		EFF7A4702271E47400F1AC33 /* Cartfile.private */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		EFF7A4712271E47500F1AC33 /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
@@ -295,6 +297,7 @@
 				098CB1341B5FAD5A00712DF9 /* ZMAssetsPreprocessor.m */,
 				098CB1351B5FAD5A00712DF9 /* ZMImageDownsampleOperation.h */,
 				098CB1361B5FAD5A00712DF9 /* ZMImageDownsampleOperation.m */,
+				A9626B4A26932BE90043CC31 /* ZMImageDownsampleOperation.swift */,
 				098CB1371B5FAD5A00712DF9 /* ZMImageLoadOperation.h */,
 				098CB1381B5FAD5A00712DF9 /* ZMImageLoadOperation.m */,
 				098CB1391B5FAD5A00712DF9 /* ZMImageOwner.h */,
@@ -637,6 +640,7 @@
 				096960351B663EF0006DF53B /* ZMImagePreprocessor.m in Sources */,
 				096960321B663EF0006DF53B /* ZMImageLoadOperation.m in Sources */,
 				0969602E1B663EF0006DF53B /* ZMAssetsPreprocessor.m in Sources */,
+				A9626B4B26932BEA0043CC31 /* ZMImageDownsampleOperation.swift in Sources */,
 				09BCDB5D1BC68F720020DCC7 /* ZMImageOwner.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## What's new in this PR?
On M1 simulator, mime can not be converted form UTI String. The temporary solution is hard code the return MIME for PNG/JPEG types if `preferredMIMEType` returns nil.
I will file a ticket to apple for this issue.